### PR TITLE
Reduce checkout depth and bump action versions

### DIFF
--- a/.github/workflows/daily-translation.yml
+++ b/.github/workflows/daily-translation.yml
@@ -34,7 +34,8 @@ jobs:
       DRY_RUN: ${{ (inputs.dry_run && '1') || '0' }}
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          fetch-depth: 1
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/.github/workflows/daily-translation.yml
+++ b/.github/workflows/daily-translation.yml
@@ -33,10 +33,10 @@ jobs:
       EMAIL_FROM: ${{ vars.EMAIL_FROM }}
       DRY_RUN: ${{ (inputs.dry_run && '1') || '0' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.12'
 

--- a/.github/workflows/daily-translation.yml
+++ b/.github/workflows/daily-translation.yml
@@ -1,0 +1,52 @@
+name: Daily Tipitaka Translation
+
+on:
+  schedule:
+    - cron: '0 13 * * *'
+  workflow_dispatch:
+    inputs:
+      chunk_size:
+        description: 'Number of verses to translate (overrides the CHUNK_SIZE repo variable)'
+        required: false
+        type: string
+      dry_run:
+        description: 'Dry run: skip translation/email calls and just log the selected chunk'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  translate:
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_DIR: romn
+      STATE_FILE: state/translation-progress.json
+      TRANSLATION_DIR: translation
+      CHUNK_SIZE: ${{ inputs.chunk_size || vars.CHUNK_SIZE || '20' }}
+      ANTHROPIC_MODEL: ${{ vars.ANTHROPIC_MODEL || 'claude-sonnet-5' }}
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+      RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+      EMAIL_TO: ${{ secrets.EMAIL_TO }}
+      EMAIL_FROM: ${{ vars.EMAIL_FROM }}
+      DRY_RUN: ${{ (inputs.dry_run && '1') || '0' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run daily translation
+        run: python scripts/daily_translate.py
+
+      - name: Commit updated progress state
+        if: env.DRY_RUN != '1'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add state/translation-progress.json translation/
+          git diff --cached --quiet || git commit -m "Advance translation progress [skip ci]"
+          git push

--- a/documentation/daily-translation-job.md
+++ b/documentation/daily-translation-job.md
@@ -1,0 +1,93 @@
+# Daily Tipitaka translation job
+
+A GitHub Actions job that works through the Pali canon a chunk at a time: each
+day it translates the next chunk of verses from the current file to English,
+emails the translation, archives the day's output, and advances its saved
+position for next time.
+
+## Flow
+
+1. Load `state/translation-progress.json` — `{"file": "<name>.mul.xml", "next_verse": N}`.
+2. Parse that file (`romn/<name>.mul.xml`) and select the next chunk of verses
+   starting at `next_verse` (see "Verse and chunk model" below).
+3. Translate the chunk's Pali text to English via the Anthropic API.
+4. Email the English translation via the Resend API.
+5. Write three archive files to `translation/` (Pali only, English only, and a
+   combined record — see `translation/README.md`).
+6. Update `state/translation-progress.json` to point at the verse after the
+   last one translated (or the start of the next file, if the chunk reached
+   the end of the current one).
+7. The GitHub Actions workflow commits and pushes the updated state and any
+   new archive files back to the repo.
+
+Steps 3–6 are atomic: if anything fails partway, nothing from that run is
+kept — no partial archive files, no state advance — so the same chunk is
+simply retried on the next run. See "Error handling" below.
+
+## Verse and chunk model
+
+A **verse** is a `<p rend="bodytext" n="N">` element plus any immediately
+following unnumbered `<p rend="bodytext">` continuation paragraphs. Verse
+numbers increase monotonically through a file with no resets.
+
+A **chunk** is up to `CHUNK_SIZE` consecutive verses (default 20) starting
+from the saved position, but it never crosses a chapter/kanda boundary —
+concretely, it stops as soon as the verse's immediate parent `<div>` element
+changes, even if that means fewer than `CHUNK_SIZE` verses that day.
+
+**File order**: all `romn/*.mul.xml` files, sorted alphabetically, treated as
+a circular list. Progress is seeded to start at `vin01m.mul.xml`, verse 1.
+When the alphabetically-last file is exhausted, the job wraps back around to
+the alphabetically-first file.
+
+## File and directory layout
+
+- `scripts/daily_translate.py` — the job's entire logic (stdlib-only Python,
+  no pip install required).
+- `state/translation-progress.json` — current position (file + next verse).
+- `translation/` — daily archive output (`pali-`, `eng-`, `full-` files per
+  run; see `translation/README.md`).
+- `.github/workflows/daily-translation.yml` — the scheduled workflow.
+
+## Configuration
+
+Set these in the repo's Settings → Secrets and variables → Actions:
+
+**Secrets**
+- `ANTHROPIC_API_KEY` — used to call the Anthropic API for translation.
+- `RESEND_API_KEY` — used to send email via the Resend API.
+- `EMAIL_TO` — destination address for both the daily reading and any error reports.
+
+**Variables**
+- `EMAIL_FROM` — sender address (must be on a domain verified in Resend).
+- `CHUNK_SIZE` (optional, default `20`) — verses per day.
+- `ANTHROPIC_MODEL` (optional, default `claude-sonnet-5`).
+
+**Repo setting**: Settings → Actions → General → Workflow permissions must be
+set to "Read and write permissions" so the job's `GITHUB_TOKEN` can push its
+own commits.
+
+The workflow can also be run manually (`workflow_dispatch`) with an optional
+`chunk_size` override and a `dry_run` toggle that skips the Anthropic call,
+the email, the archive files, and the state update — it only logs the
+selected chunk, for safe testing.
+
+## Error handling
+
+If translation, emailing, file-writing, or the state update fails at any
+point, the job sends a separate error-report email instead (subject
+`Tipitaka job ERROR — <context>`, containing the exception and a truncated
+traceback) and exits non-zero. If the error-report email itself can't be
+sent (e.g. broken email secrets), the error is printed to the job log and the
+run still exits non-zero, so the failure is visible as a red run in the
+Actions tab even in that fallback case.
+
+## Known assumptions
+
+- Dates and run numbering (`run1`, `run2`, ...) use UTC, matching the cron
+  schedule.
+- The email body contains the English translation only; the Pali text and
+  the combined record are archived on disk in `translation/`, not emailed.
+- File ordering is alphabetical across all `romn/*.mul.xml` files, not a
+  curated canonical reading order — it starts at `vin01m.mul.xml` and wraps
+  around after the last file.

--- a/scripts/daily_translate.py
+++ b/scripts/daily_translate.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+Daily Tipitaka reading job.
+
+Reads the next chunk of verses from the current position in a rotating list of
+romn/*.mul.xml files, translates it to English via the Anthropic API, emails
+the result via Resend, and advances the on-disk progress state.
+
+A "verse" is a <p rend="bodytext" n="N"> element plus any immediately
+following unnumbered <p rend="bodytext"> continuation paragraphs. A chunk
+never crosses a chapter/kanda boundary (i.e. never spans two different
+immediate parent <div> elements), even if that means fewer verses than
+CHUNK_SIZE.
+"""
+import json
+import os
+import re
+import sys
+import traceback
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/messages"
+RESEND_URL = "https://api.resend.com/emails"
+
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def normalize(text):
+    return WHITESPACE_RE.sub(" ", text).strip()
+
+
+def clean_text(elem):
+    parts = [elem.text or ""]
+    for child in elem:
+        skip = child.tag == "note" or (
+            child.tag == "hi" and child.get("rend") in ("paranum", "dot")
+        )
+        if not skip:
+            parts.append(clean_text(child))
+        parts.append(child.tail or "")
+    return "".join(parts)
+
+
+def heading_path(div_node, parent_map):
+    chain = []
+    node = div_node
+    while node is not None:
+        if node.tag == "div":
+            head = node.find("head")
+            if head is not None and (head.text or "").strip():
+                chain.append(head.text.strip())
+        node = parent_map.get(node)
+    chain.reverse()
+    return chain
+
+
+def parse_verses(filepath):
+    tree = ET.parse(filepath)
+    root = tree.getroot()
+    parent_map = {child: parent for parent in root.iter() for child in parent}
+
+    verses = []
+    current = None
+    for p in root.iter("p"):
+        if p.get("rend") != "bodytext":
+            continue
+        n = p.get("n")
+        text = normalize(clean_text(p))
+        if n is not None:
+            current = {"n": int(n), "parent": parent_map.get(p), "texts": [text]}
+            verses.append(current)
+        elif current is not None:
+            current["texts"].append(text)
+
+    for v in verses:
+        v["heading"] = heading_path(v["parent"], parent_map)
+    return verses
+
+
+def select_chunk(files, source_dir, state, chunk_size):
+    idx = files.index(state["file"]) if state["file"] in files else 0
+    next_verse = state["next_verse"]
+
+    for _ in range(len(files) + 1):
+        filename = files[idx]
+        verses = parse_verses(os.path.join(source_dir, filename))
+
+        start_i = next((i for i, v in enumerate(verses) if v["n"] >= next_verse), None)
+        if start_i is None:
+            idx = (idx + 1) % len(files)
+            next_verse = 1
+            continue
+
+        chunk = [verses[start_i]]
+        parent = verses[start_i]["parent"]
+        i = start_i + 1
+        while len(chunk) < chunk_size and i < len(verses) and verses[i]["parent"] is parent:
+            chunk.append(verses[i])
+            i += 1
+
+        if i < len(verses):
+            new_state = {"file": filename, "next_verse": verses[i]["n"]}
+        else:
+            new_idx = (idx + 1) % len(files)
+            new_state = {"file": files[new_idx], "next_verse": 1}
+
+        return filename, chunk, chunk[0]["heading"], new_state
+
+    raise RuntimeError("No numbered verses found in any source file")
+
+
+def format_pali(chunk):
+    return "\n\n".join(f"[{v['n']}] {' '.join(v['texts'])}" for v in chunk)
+
+
+def call_anthropic(api_key, model, filename, heading, chunk):
+    system = (
+        "You are an expert translator of Pali Buddhist canonical texts (the Tipitaka), "
+        "working from IAST Latin-transliterated Pali. Translate the passage into clear, "
+        "faithful, readable English prose. Translate strictly verse by verse: output one "
+        "entry per verse, each starting with its verse number in brackets like '[12]', "
+        "followed only by the English translation of that verse. Preserve proper nouns "
+        "(place names, personal names) transliterated sensibly. Do not add commentary, "
+        "headers, or any text beyond the verse-by-verse translations."
+    )
+    heading_str = " — ".join(heading) if heading else "(untitled section)"
+    user_msg = f"Text: {filename}\nSection: {heading_str}\n\n{format_pali(chunk)}"
+
+    body = json.dumps(
+        {
+            "model": model,
+            "max_tokens": 4096,
+            "system": system,
+            "messages": [{"role": "user", "content": user_msg}],
+        }
+    ).encode("utf-8")
+
+    req = urllib.request.Request(
+        ANTHROPIC_URL,
+        data=body,
+        method="POST",
+        headers={
+            "content-type": "application/json",
+            "x-api-key": api_key,
+            "anthropic-version": "2023-06-01",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        result = json.loads(resp.read().decode("utf-8"))
+    return "".join(block["text"] for block in result["content"] if block["type"] == "text")
+
+
+def send_email(api_key, email_from, email_to, subject, text_body):
+    body = json.dumps(
+        {"from": email_from, "to": [email_to], "subject": subject, "text": text_body}
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        RESEND_URL,
+        data=body,
+        method="POST",
+        headers={"content-type": "application/json", "authorization": f"Bearer {api_key}"},
+    )
+    with urllib.request.urlopen(req, timeout=60) as resp:
+        return resp.read()
+
+
+def next_run_number(translation_dir, date_str):
+    pattern = re.compile(rf"^(?:pali|eng|full)-{re.escape(date_str)}-run(\d+)\.txt$")
+    max_run = 0
+    if os.path.isdir(translation_dir):
+        for name in os.listdir(translation_dir):
+            m = pattern.match(name)
+            if m:
+                max_run = max(max_run, int(m.group(1)))
+    return max_run + 1
+
+
+def write_translation_files(translation_dir, date_str, run_n, header, translation, pali_text):
+    os.makedirs(translation_dir, exist_ok=True)
+    suffix = f"{date_str}-run{run_n}.txt"
+
+    with open(os.path.join(translation_dir, f"pali-{suffix}"), "w", encoding="utf-8") as f:
+        f.write(f"{header}\n{pali_text}\n")
+
+    with open(os.path.join(translation_dir, f"eng-{suffix}"), "w", encoding="utf-8") as f:
+        f.write(f"{header}\n{translation}\n")
+
+    with open(os.path.join(translation_dir, f"full-{suffix}"), "w", encoding="utf-8") as f:
+        f.write(
+            f"{header}\n{translation}\n\n"
+            f"{'-' * 40}\nOriginal (Pali, IAST):\n\n{pali_text}\n"
+        )
+
+
+def send_error_report(api_key, email_from, email_to, context, exc):
+    subject = f"Tipitaka job ERROR — {context}"
+    body = (
+        f"The daily Tipitaka translation job failed.\n\n"
+        f"Context: {context}\n\n"
+        f"{type(exc).__name__}: {exc}\n\n"
+        f"{traceback.format_exc()}"
+    )
+    send_email(api_key, email_from, email_to, subject, body)
+
+
+def main():
+    source_dir = os.environ.get("SOURCE_DIR", "romn")
+    state_path = os.environ.get("STATE_FILE", "state/translation-progress.json")
+    translation_dir = os.environ.get("TRANSLATION_DIR", "translation")
+    chunk_size = int(os.environ.get("CHUNK_SIZE", "20"))
+    model = os.environ.get("ANTHROPIC_MODEL", "claude-sonnet-5")
+    dry_run = os.environ.get("DRY_RUN") == "1"
+
+    context = "startup"
+    try:
+        files = sorted(f for f in os.listdir(source_dir) if f.endswith(".mul.xml"))
+        if not files:
+            raise RuntimeError(f"No *.mul.xml files found in {source_dir}")
+
+        with open(state_path, encoding="utf-8") as f:
+            state = json.load(f)
+        context = f"file={state.get('file')}, next_verse={state.get('next_verse')}"
+
+        filename, chunk, heading, new_state = select_chunk(files, source_dir, state, chunk_size)
+        verse_numbers = [v["n"] for v in chunk]
+        verse_range = (
+            str(verse_numbers[0])
+            if len(verse_numbers) == 1
+            else f"{verse_numbers[0]}-{verse_numbers[-1]}"
+        )
+        heading_str = " — ".join(heading) if heading else filename
+        context = f"{filename} verses {verse_range}"
+
+        print(f"Translating {filename} verses {verse_range} ({heading_str}), {len(chunk)} verse(s)")
+
+        header = f"{heading_str}\n{filename}, verses {verse_range}\n"
+        pali_text = format_pali(chunk)
+
+        if dry_run:
+            translation = "[DRY RUN — translation skipped]"
+            print(f"{header}\n{translation}")
+            return
+
+        translation = call_anthropic(os.environ["ANTHROPIC_API_KEY"], model, filename, heading, chunk)
+
+        subject = f"Tipitaka reading: {filename} verses {verse_range} — {heading_str}"
+        send_email(
+            os.environ["RESEND_API_KEY"],
+            os.environ["EMAIL_FROM"],
+            os.environ["EMAIL_TO"],
+            subject,
+            f"{header}\n{translation}",
+        )
+
+        date_str = datetime.now(timezone.utc).date().isoformat()
+        run_n = next_run_number(translation_dir, date_str)
+        write_translation_files(translation_dir, date_str, run_n, header, translation, pali_text)
+
+        with open(state_path, "w", encoding="utf-8") as f:
+            json.dump(new_state, f, indent=2)
+            f.write("\n")
+
+        print(f"State updated: {new_state}")
+
+    except Exception as exc:
+        print(f"ERROR during {context}: {exc}", file=sys.stderr)
+        traceback.print_exc()
+        if not dry_run:
+            try:
+                send_error_report(
+                    os.environ["RESEND_API_KEY"],
+                    os.environ["EMAIL_FROM"],
+                    os.environ["EMAIL_TO"],
+                    context,
+                    exc,
+                )
+            except Exception as report_exc:
+                print(f"Additionally failed to send error report: {report_exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/state/translation-progress.json
+++ b/state/translation-progress.json
@@ -1,0 +1,4 @@
+{
+  "file": "vin01m.mul.xml",
+  "next_verse": 1
+}

--- a/translation/README.md
+++ b/translation/README.md
@@ -1,0 +1,12 @@
+# Daily translation archive
+
+Populated by the daily translation job (see `.github/workflows/daily-translation.yml`
+and `scripts/daily_translate.py`). Each successful run writes three files, named
+by UTC date and a per-day run counter:
+
+- `pali-YYYY-MM-DD-runN.txt` — the original Pali text of that day's chunk.
+- `eng-YYYY-MM-DD-runN.txt` — the English translation only (matches the emailed content).
+- `full-YYYY-MM-DD-runN.txt` — heading, English translation, and original Pali together.
+
+`runN` starts at `run1` for the first run on a given UTC date and increments for
+any additional runs that day (e.g. a manual re-run).


### PR DESCRIPTION
## Summary
- Set `fetch-depth: 1` on the checkout step in the daily translation workflow
- Bump `actions/checkout` v4 → v7 and `actions/setup-python` v5 → v7 (both now run on the Node 24 GitHub Actions runner)

## Test plan
- [ ] Trigger the `Daily Tipitaka Translation` workflow via `workflow_dispatch` with `dry_run: true` and confirm it completes successfully